### PR TITLE
Feature/endpoint security

### DIFF
--- a/src/main/java/edu/aau/groupc/canteenbackend/auth/Auth.java
+++ b/src/main/java/edu/aau/groupc/canteenbackend/auth/Auth.java
@@ -8,7 +8,7 @@ import javax.persistence.*;
 @Data
 @Entity
 @Table(name = "auth", uniqueConstraints = {
-        @UniqueConstraint(columnNames = {"username", "token"}),
+        @UniqueConstraint(columnNames = {"token"}),
 })
 public class Auth implements DBEntity {
 
@@ -85,5 +85,10 @@ public class Auth implements DBEntity {
 
     public void setTimeEnd(long maxDuration) {
         this.timeEnd = this.timeStart + maxDuration;
+    }
+
+    public boolean isNotExpired() {
+        long now = System.currentTimeMillis();
+        return now >= timeStart && now <= timeEnd;
     }
 }

--- a/src/main/java/edu/aau/groupc/canteenbackend/auth/controllers/LoginController.java
+++ b/src/main/java/edu/aau/groupc/canteenbackend/auth/controllers/LoginController.java
@@ -5,6 +5,7 @@ import edu.aau.groupc.canteenbackend.auth.dto.LoginDto;
 import edu.aau.groupc.canteenbackend.auth.dto.LogoutDto;
 import edu.aau.groupc.canteenbackend.auth.services.IAuthService;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -18,6 +19,9 @@ import java.util.Map;
 
 @RestController
 public class LoginController {
+
+    @Value("${app.auth.header}")
+    private String tokenHeader;
 
     private IAuthService authService;
 
@@ -38,7 +42,7 @@ public class LoginController {
         HttpHeaders headers = new HttpHeaders();
         List<String> headersList = new ArrayList<>();
         headersList.add(auth.getToken());
-        headers.put("Auth-Token", headersList);
+        headers.put(tokenHeader, headersList);
 
         return new ResponseEntity<>("Logged in successfully.", headers, HttpStatus.OK);
     }

--- a/src/main/java/edu/aau/groupc/canteenbackend/auth/repositories/IAuthRepository.java
+++ b/src/main/java/edu/aau/groupc/canteenbackend/auth/repositories/IAuthRepository.java
@@ -12,4 +12,5 @@ public interface IAuthRepository extends JpaRepository<Auth, Long> {
 
     Optional<Auth> getAuthByUsernameAndToken(String username, String token);
 
+    Optional<Auth> getAuthByToken(String token);
 }

--- a/src/main/java/edu/aau/groupc/canteenbackend/auth/security/AuthenticationInterceptor.java
+++ b/src/main/java/edu/aau/groupc/canteenbackend/auth/security/AuthenticationInterceptor.java
@@ -23,10 +23,10 @@ import java.util.Optional;
 public class AuthenticationInterceptor implements HandlerInterceptor {
 
     @Value("${app.auth.header}")
-    private String tokenHeader;
+    protected String tokenHeader;
 
     @Autowired
-    private IAuthService authService;
+    protected IAuthService authService;
 
     /**
      * Authenticate user and check authorization.
@@ -77,7 +77,10 @@ public class AuthenticationInterceptor implements HandlerInterceptor {
      * @param requiredType Type the user must at least have.
      * @return True, if authorized.
      */
-    private boolean isAuthorized(User user, User.Type requiredType) {
+    boolean isAuthorized(User user, User.Type requiredType) {
+        if (user == null) {
+            return false;
+        }
         User.Type userType = user.getType();
         if (userType == User.Type.OWNER) {
             return true;
@@ -99,7 +102,7 @@ public class AuthenticationInterceptor implements HandlerInterceptor {
      * @param request Request
      * @return Optional of token
      */
-    private Optional<String> getToken(HttpServletRequest request) {
+    Optional<String> getToken(HttpServletRequest request) {
         return Optional.ofNullable(request.getHeader(tokenHeader));
     }
 
@@ -109,7 +112,7 @@ public class AuthenticationInterceptor implements HandlerInterceptor {
      * @return User Type of associated @Secured annotation,
      *         or GUEST if no @Secured is present or if no value is set.
      */
-    private User.Type getRequiredUserRole(AnnotatedElement e) {
+    User.Type getRequiredUserRole(AnnotatedElement e) {
         if (e == null) {
             return User.Type.GUEST;
         }

--- a/src/main/java/edu/aau/groupc/canteenbackend/auth/security/AuthenticationInterceptor.java
+++ b/src/main/java/edu/aau/groupc/canteenbackend/auth/security/AuthenticationInterceptor.java
@@ -1,0 +1,122 @@
+package edu.aau.groupc.canteenbackend.auth.security;
+
+import edu.aau.groupc.canteenbackend.auth.services.IAuthService;
+import edu.aau.groupc.canteenbackend.user.User;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatus;
+import org.springframework.lang.NonNull;
+import org.springframework.stereotype.Component;
+import org.springframework.web.method.HandlerMethod;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.lang.reflect.AnnotatedElement;
+import java.util.Optional;
+
+/**
+ * Interceptor handling authentication
+ */
+
+@Component
+public class AuthenticationInterceptor implements HandlerInterceptor {
+
+    @Value("${app.auth.header}")
+    private String tokenHeader;
+
+    @Autowired
+    private IAuthService authService;
+
+    /**
+     * Authenticate user and check authorization.
+     * @param request Request
+     * @param response Response
+     * @param handler Handler
+     * @return True if we wish to continue, false if wish to abort.
+     */
+    @Override
+    public boolean preHandle(
+            @NonNull HttpServletRequest request,
+            @NonNull HttpServletResponse response,
+            @NonNull Object handler) {
+
+        User.Type requiredUserType = User.Type.GUEST;
+
+        if(handler instanceof HandlerMethod handlerMethod) {
+            requiredUserType = getRequiredUserRole(handlerMethod.getMethod());
+        }
+        // Guests can perform actions without authentication
+        if (requiredUserType != User.Type.GUEST) {
+            Optional<String> token = getToken(request);
+            if (token.isEmpty() || !authService.isValidLogin(token.get())) {
+                response.setStatus(HttpStatus.UNAUTHORIZED.value());
+                return false;
+            }
+            User authenticatedUser = authService.getUserByToken(token.get());
+            if (authenticatedUser == null) {
+                response.setStatus(HttpStatus.UNAUTHORIZED.value());
+                return false;
+            }
+            if (!isAuthorized(authenticatedUser, requiredUserType)) {
+                response.setStatus(HttpStatus.FORBIDDEN.value());
+                return false;
+            }
+
+            // set user as a request attribute which can be accessed in any secured controller (endpoint) method
+            request.setAttribute("user", authenticatedUser);
+        }
+
+        return true;
+    }
+
+    /**
+     * Check whether a user is authorized for a required user type following the hierarchy
+     * OWNER > ADMIN > USER > GUEST
+     * @param user User
+     * @param requiredType Type the user must at least have.
+     * @return True, if authorized.
+     */
+    private boolean isAuthorized(User user, User.Type requiredType) {
+        User.Type userType = user.getType();
+        if (userType == User.Type.OWNER) {
+            return true;
+        }
+        if (userType == User.Type.ADMIN) {
+            return requiredType != User.Type.OWNER;
+        }
+        if (userType == User.Type.USER) {
+            return requiredType != User.Type.OWNER && requiredType != User.Type.ADMIN;
+        }
+        if (userType == User.Type.GUEST) {
+            return requiredType == User.Type.GUEST;
+        }
+        return false;
+    }
+
+    /**
+     * Extract auth token from request header.
+     * @param request Request
+     * @return Optional of token
+     */
+    private Optional<String> getToken(HttpServletRequest request) {
+        return Optional.ofNullable(request.getHeader(tokenHeader));
+    }
+
+    /**
+     * Get the User.Type value of a @Secured annotated element.
+     * @param e Annotated element (such as a Method)
+     * @return User Type of associated @Secured annotation,
+     *         or GUEST if no @Secured is present or if no value is set.
+     */
+    private User.Type getRequiredUserRole(AnnotatedElement e) {
+        if (e == null) {
+            return User.Type.GUEST;
+        }
+        Secured secured = e.getAnnotation(Secured.class);
+        if (secured == null) {
+            return User.Type.GUEST;
+        }
+        return secured.value();
+    }
+}

--- a/src/main/java/edu/aau/groupc/canteenbackend/auth/security/Secured.java
+++ b/src/main/java/edu/aau/groupc/canteenbackend/auth/security/Secured.java
@@ -11,5 +11,5 @@ import static java.lang.annotation.ElementType.METHOD;
 @Retention(RetentionPolicy.RUNTIME)
 @Target({METHOD})
 public @interface Secured {
-    User.Type value() default User.Type.GUEST;
+    User.Type value() default User.Type.USER;
 }

--- a/src/main/java/edu/aau/groupc/canteenbackend/auth/security/Secured.java
+++ b/src/main/java/edu/aau/groupc/canteenbackend/auth/security/Secured.java
@@ -1,0 +1,15 @@
+package edu.aau.groupc.canteenbackend.auth.security;
+
+import edu.aau.groupc.canteenbackend.user.User;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.METHOD;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target({METHOD})
+public @interface Secured {
+    User.Type value() default User.Type.GUEST;
+}

--- a/src/main/java/edu/aau/groupc/canteenbackend/auth/services/AuthService.java
+++ b/src/main/java/edu/aau/groupc/canteenbackend/auth/services/AuthService.java
@@ -9,6 +9,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Optional;
 
 @Transactional
 @Service
@@ -54,5 +55,29 @@ public class AuthService implements IAuthService {
         }
 
         return this.userRepository.getUserByUsername(username);
+    }
+
+    @Override
+    public Boolean isValidLogin(String token) {
+        if (token == null) {
+            return false;
+        }
+        Optional<Auth> auth = authRepository.getAuthByToken(token);
+        if (auth.isEmpty()) {
+            return false;
+        }
+        return auth.get().isNotExpired();
+    }
+
+    @Override
+    public User getUserByToken(String token) {
+        if (token == null) {
+            return null;
+        }
+        Optional<Auth> auth = authRepository.getAuthByToken(token);
+        if (auth.isEmpty()) {
+            return null;
+        }
+        return userRepository.getUserByUsername(auth.get().getUsername());
     }
 }

--- a/src/main/java/edu/aau/groupc/canteenbackend/auth/services/AuthService.java
+++ b/src/main/java/edu/aau/groupc/canteenbackend/auth/services/AuthService.java
@@ -58,7 +58,7 @@ public class AuthService implements IAuthService {
     }
 
     @Override
-    public Boolean isValidLogin(String token) {
+    public boolean isValidLogin(String token) {
         if (token == null) {
             return false;
         }

--- a/src/main/java/edu/aau/groupc/canteenbackend/auth/services/IAuthService.java
+++ b/src/main/java/edu/aau/groupc/canteenbackend/auth/services/IAuthService.java
@@ -17,4 +17,7 @@ public interface IAuthService {
 
     User getUserByUsernameAndToken(String username, String token);
 
+    Boolean isValidLogin(String token);
+
+    User getUserByToken(String token);
 }

--- a/src/main/java/edu/aau/groupc/canteenbackend/auth/services/IAuthService.java
+++ b/src/main/java/edu/aau/groupc/canteenbackend/auth/services/IAuthService.java
@@ -17,7 +17,7 @@ public interface IAuthService {
 
     User getUserByUsernameAndToken(String username, String token);
 
-    Boolean isValidLogin(String token);
+    boolean isValidLogin(String token);
 
     User getUserByToken(String token);
 }

--- a/src/main/java/edu/aau/groupc/canteenbackend/config/WebConfig.java
+++ b/src/main/java/edu/aau/groupc/canteenbackend/config/WebConfig.java
@@ -1,5 +1,6 @@
 package edu.aau.groupc.canteenbackend.config;
 
+import edu.aau.groupc.canteenbackend.auth.security.AuthenticationInterceptor;
 import org.apache.tomcat.util.http.Rfc6265CookieProcessor;
 import org.apache.tomcat.util.http.SameSiteCookies;
 import org.springframework.boot.web.embedded.tomcat.TomcatContextCustomizer;
@@ -7,6 +8,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.EnableWebMvc;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 @Configuration
@@ -29,5 +31,15 @@ public class WebConfig implements WebMvcConfigurer {
             cookieProcessor.setSameSiteCookies(SameSiteCookies.NONE.getValue());
             context.setCookieProcessor(cookieProcessor);
         };
+    }
+
+    @Bean
+    public AuthenticationInterceptor authInterceptor() {
+        return new AuthenticationInterceptor();
+    }
+
+    @Override
+    public void addInterceptors(InterceptorRegistry registry){
+        registry.addInterceptor(authInterceptor());
     }
 }

--- a/src/main/java/edu/aau/groupc/canteenbackend/endpoints/DishController.java
+++ b/src/main/java/edu/aau/groupc/canteenbackend/endpoints/DishController.java
@@ -1,8 +1,10 @@
 package edu.aau.groupc.canteenbackend.endpoints;
 
+import edu.aau.groupc.canteenbackend.auth.security.Secured;
 import edu.aau.groupc.canteenbackend.dto.DishDTO;
 import edu.aau.groupc.canteenbackend.entities.Dish;
 import edu.aau.groupc.canteenbackend.services.IDishService;
+import edu.aau.groupc.canteenbackend.user.User;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.*;
 
@@ -23,6 +25,7 @@ public class DishController {
         return dishService.findAll();
     }
 
+    @Secured(User.Type.USER)
     @PostMapping(value = "/dish")
     public Dish createDish(@RequestBody DishDTO newDish)
     {

--- a/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -1,0 +1,8 @@
+{
+  "properties": [
+    {
+      "name": "app.auth.header",
+      "type": "java.lang.String",
+      "description": "Name of the HTTP header used for the authentication token."
+  }
+] }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -18,3 +18,5 @@ server.ssl.enabled=false
 # Enable logging of CSRF filter
 logging.level.org.springframework.security.web.csrf=DEBUG
 spring.mvc.dispatch-options-request=true
+
+app.auth.header=Auth-Token

--- a/src/test/java/edu/aau/groupc/canteenbackend/auth/security/AuthTestController.java
+++ b/src/test/java/edu/aau/groupc/canteenbackend/auth/security/AuthTestController.java
@@ -1,0 +1,55 @@
+package edu.aau.groupc.canteenbackend.auth.security;
+
+import edu.aau.groupc.canteenbackend.user.User;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("authtest")
+public class AuthTestController {
+
+    @GetMapping(value = "/unsecured")
+    public ResponseEntity<String> unsecured()
+    {
+        return new ResponseEntity<>("Data", new HttpHeaders(), HttpStatus.OK);
+    }
+
+    @Secured
+    @GetMapping(value = "/securedNoType")
+    public ResponseEntity<String> securedNoType()
+    {
+        return new ResponseEntity<>("Data", new HttpHeaders(), HttpStatus.OK);
+    }
+
+    @Secured(User.Type.GUEST)
+    @GetMapping(value = "/securedGuest")
+    public ResponseEntity<String> securedGuest()
+    {
+        return new ResponseEntity<>("Data", new HttpHeaders(), HttpStatus.OK);
+    }
+
+    @Secured(User.Type.USER)
+    @GetMapping(value = "/securedUser")
+    public ResponseEntity<String> securedUser()
+    {
+        return new ResponseEntity<>("Data", new HttpHeaders(), HttpStatus.OK);
+    }
+
+    @Secured(User.Type.ADMIN)
+    @GetMapping(value = "/securedAdmin")
+    public ResponseEntity<String> securedAdmin()
+    {
+        return new ResponseEntity<>("Data", new HttpHeaders(), HttpStatus.OK);
+    }
+
+    @Secured(User.Type.OWNER)
+    @GetMapping(value = "/securedOwner")
+    public ResponseEntity<String> securedOwner()
+    {
+        return new ResponseEntity<>("Data", new HttpHeaders(), HttpStatus.OK);
+    }
+}

--- a/src/test/java/edu/aau/groupc/canteenbackend/auth/security/AuthTestController.java
+++ b/src/test/java/edu/aau/groupc/canteenbackend/auth/security/AuthTestController.java
@@ -8,6 +8,8 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import javax.servlet.http.HttpServletRequest;
+
 @RestController
 @RequestMapping("authtest")
 public class AuthTestController {
@@ -51,5 +53,12 @@ public class AuthTestController {
     public ResponseEntity<String> securedOwner()
     {
         return new ResponseEntity<>("Data", new HttpHeaders(), HttpStatus.OK);
+    }
+
+    @Secured(User.Type.USER)
+    @GetMapping(value = "/securedUserReturnUserData")
+    public ResponseEntity<User> securedUserReturnUserData(HttpServletRequest request)
+    {
+        return new ResponseEntity<>((User) request.getAttribute("user"), new HttpHeaders(), HttpStatus.OK);
     }
 }

--- a/src/test/java/edu/aau/groupc/canteenbackend/auth/security/AuthenticationInterceptorIntegrationTest.java
+++ b/src/test/java/edu/aau/groupc/canteenbackend/auth/security/AuthenticationInterceptorIntegrationTest.java
@@ -1,0 +1,162 @@
+package edu.aau.groupc.canteenbackend.auth.security;
+
+import edu.aau.groupc.canteenbackend.auth.Auth;
+import edu.aau.groupc.canteenbackend.auth.services.IAuthService;
+import edu.aau.groupc.canteenbackend.endpoints.AbstractControllerTest;
+import edu.aau.groupc.canteenbackend.user.User;
+import edu.aau.groupc.canteenbackend.user.services.IUserService;
+import org.json.JSONException;
+import org.json.JSONObject;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.web.client.HttpClientErrorException;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@ActiveProfiles("H2Database")
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class AuthenticationInterceptorIntegrationTest extends AbstractControllerTest {
+    @Autowired
+    private IUserService userService;
+
+    @Autowired
+    private IAuthService authService;
+
+    @Value("${app.auth.header}")
+    private String tokenHeader;
+
+    private Map<User.Type, Auth> tokens;
+
+    @BeforeAll
+    void setupUsersAndAuth() {
+        User user = new User("someUser", "somePassword", User.Type.USER);
+        User admin = new User("someAdmin", "somePassword", User.Type.ADMIN);
+        User owner = new User("someOwner", "somePassword", User.Type.OWNER);
+
+        userService.create(user);
+        userService.create(admin);
+        userService.create(owner);
+
+        tokens = new HashMap<>();
+        tokens.put(User.Type.USER, authService.login(user.getUsername(), user.getPassword()));
+        tokens.put(User.Type.ADMIN, authService.login(admin.getUsername(), admin.getPassword()));
+        tokens.put(User.Type.OWNER, authService.login(owner.getUsername(), owner.getPassword()));
+    }
+
+    private HttpHeaders getTokenHeader(User.Type userType) {
+        try {
+            return getTokenHeader(tokens.get(userType).getToken());
+        } catch (RuntimeException e) {
+            return new HttpHeaders();
+        }
+    }
+
+    private HttpHeaders getTokenHeader(String token) {
+        try {
+            HttpHeaders headers = new HttpHeaders();
+            headers.put(tokenHeader, List.of(token));
+            return headers;
+        } catch (RuntimeException e) {
+            return new HttpHeaders();
+        }
+    }
+
+    @Test
+    void testUnsecured_NotAuthenticated_ThenOK() {
+        ResponseEntity<String> response = makeGetRequest("/authtest/unsecured");
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"/authtest/unsecured", "/authtest/securedNoType",
+            "/authtest/securedGuest", "/authtest/securedUser"})
+    void testUser_ThenOK(String path) {
+        ResponseEntity<String> response = makeGetRequest(path, getTokenHeader(User.Type.USER));
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"/authtest/securedNoType", "/authtest/securedUser",
+            "/authtest/securedAdmin", "/authtest/securedOwner"})
+    void testNotAuthenticated_ThenUnauthorized(String path) {
+        HttpClientErrorException exception = assertThrows(HttpClientErrorException.class, () ->
+                makeGetRequest(path));
+        assertEquals(HttpStatus.UNAUTHORIZED, exception.getStatusCode());
+    }
+
+    @Test
+    void testSecuredGuest_NotAuthenticated_ThenOK() {
+        ResponseEntity<String> response = makeGetRequest("/authtest/securedGuest");
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+    }
+
+    @Test
+    void testSecuredUser_Admin_ThenOK() {
+        ResponseEntity<String> response = makeGetRequest("/authtest/securedUser", getTokenHeader(User.Type.ADMIN));
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"/authtest/securedUser", "/authtest/securedAdmin", "/authtest/securedOwner"})
+    void testOwner_ThenOK(String path) {
+        ResponseEntity<String> response = makeGetRequest(path, getTokenHeader(User.Type.OWNER));
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"/authtest/securedAdmin", "/authtest/securedOwner"})
+    void testUser_ThenForbidden(String path) {
+        HttpClientErrorException exception = assertThrows(HttpClientErrorException.class, () ->
+                makeGetRequest(path, getTokenHeader(User.Type.USER)));
+        assertEquals(HttpStatus.FORBIDDEN, exception.getStatusCode());
+    }
+
+    @Test
+    void testSecuredAdmin_Admin_ThenOK() {
+        ResponseEntity<String> response = makeGetRequest("/authtest/securedAdmin", getTokenHeader(User.Type.ADMIN));
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+    }
+
+    @Test
+    void testSecuredOwner_Admin_ThenForbidden() {
+        HttpClientErrorException exception = assertThrows(HttpClientErrorException.class, () ->
+                makeGetRequest("/authtest/securedOwner", getTokenHeader(User.Type.ADMIN)));
+        assertEquals(HttpStatus.FORBIDDEN, exception.getStatusCode());
+    }
+
+    @Test
+    void testSecured_InvalidToken_ThenUnauthorized() {
+        HttpClientErrorException exception = assertThrows(HttpClientErrorException.class, () ->
+                makeGetRequest("/authtest/securedUser", getTokenHeader("someInvalidToken")));
+        assertEquals(HttpStatus.UNAUTHORIZED, exception.getStatusCode());
+    }
+
+    /**
+     * Check if the user is correctly retrievable within the controller method.
+     * (Returning it via response is just for test simplification)
+     * @throws JSONException If response body cannot be parsed.
+     */
+    @Test
+    void testSecured_GetUserDataFromRequest() throws JSONException {
+        ResponseEntity<String> response = makeGetRequest("/authtest/securedUserReturnUserData",
+                getTokenHeader(User.Type.USER));
+
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        JSONObject responseJson = new JSONObject(response.getBody());
+        assertEquals(tokens.get(User.Type.USER).getUsername(), responseJson.getString("username"));
+    }
+}

--- a/src/test/java/edu/aau/groupc/canteenbackend/auth/security/AuthenticationInterceptorTest.java
+++ b/src/test/java/edu/aau/groupc/canteenbackend/auth/security/AuthenticationInterceptorTest.java
@@ -1,0 +1,186 @@
+package edu.aau.groupc.canteenbackend.auth.security;
+
+import edu.aau.groupc.canteenbackend.auth.Auth;
+import edu.aau.groupc.canteenbackend.auth.services.IAuthService;
+import edu.aau.groupc.canteenbackend.endpoints.AbstractControllerTest;
+import edu.aau.groupc.canteenbackend.user.User;
+import edu.aau.groupc.canteenbackend.user.services.IUserService;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.web.client.HttpClientErrorException;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@ActiveProfiles("H2Database")
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class AuthenticationInterceptorTest extends AbstractControllerTest {
+    @Autowired
+    private IUserService userService;
+
+    @Autowired
+    private IAuthService authService;
+
+    @Value("${app.auth.header}")
+    private String tokenHeader;
+
+    private Map<User.Type, Auth> tokens;
+
+    @BeforeAll
+    void setupUsersAndAuth() {
+        User user = new User("someUser", "somePassword", User.Type.USER);
+        User admin = new User("someAdmin", "somePassword", User.Type.ADMIN);
+        User owner = new User("someOwner", "somePassword", User.Type.OWNER);
+
+        userService.create(user);
+        userService.create(admin);
+        userService.create(owner);
+
+        tokens = new HashMap<>();
+        tokens.put(User.Type.USER, authService.login(user.getUsername(), user.getPassword()));
+        tokens.put(User.Type.ADMIN, authService.login(admin.getUsername(), admin.getPassword()));
+        tokens.put(User.Type.OWNER, authService.login(owner.getUsername(), owner.getPassword()));
+    }
+
+    private HttpHeaders getTokenHeader(User.Type userType) {
+        return getTokenHeader(tokens.get(userType).getToken());
+    }
+
+    private HttpHeaders getTokenHeader(String token) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.put(tokenHeader, List.of(token));
+        return headers;
+    }
+
+    @Test
+    void testUnsecured_NotAuthenticated_ThenOK() {
+        ResponseEntity<String> response = makeGetRequest("/authtest/unsecured");
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+    }
+
+    @Test
+    void testUnsecured_User_ThenOK() {
+        ResponseEntity<String> response = makeGetRequest("/authtest/unsecured", getTokenHeader(User.Type.USER));
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+    }
+
+    @Test
+    void testSecuredNoType_NotAuthenticated_ThenOK() {
+        ResponseEntity<String> response = makeGetRequest("/authtest/securedNoType");
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+    }
+
+    @Test
+    void testSecuredNoType_User_ThenOK() {
+        ResponseEntity<String> response = makeGetRequest("/authtest/securedNoType", getTokenHeader(User.Type.USER));
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+    }
+
+    @Test
+    void testSecuredGuest_NotAuthenticated_ThenOK() {
+        ResponseEntity<String> response = makeGetRequest("/authtest/securedGuest");
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+    }
+
+    @Test
+    void testSecuredGuest_User_ThenOK() {
+        ResponseEntity<String> response = makeGetRequest("/authtest/securedGuest", getTokenHeader(User.Type.USER));
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+    }
+
+    @Test
+    void testSecuredUser_NotAuthenticated_ThenUnauthorized() {
+        HttpClientErrorException exception = assertThrows(HttpClientErrorException.class, () ->
+                makeGetRequest("/authtest/securedUser"));
+        assertEquals(HttpStatus.UNAUTHORIZED, exception.getStatusCode());
+    }
+
+    @Test
+    void testSecuredUser_User_ThenOK() {
+        ResponseEntity<String> response = makeGetRequest("/authtest/securedUser", getTokenHeader(User.Type.USER));
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+    }
+
+    @Test
+    void testSecuredUser_Admin_ThenOK() {
+        ResponseEntity<String> response = makeGetRequest("/authtest/securedUser", getTokenHeader(User.Type.ADMIN));
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+    }
+
+    @Test
+    void testSecuredUser_Owner_ThenOK() {
+        ResponseEntity<String> response = makeGetRequest("/authtest/securedUser", getTokenHeader(User.Type.OWNER));
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+    }
+
+    @Test
+    void testSecuredAdmin_NotAuthenticated_ThenUnauthorized() {
+        HttpClientErrorException exception = assertThrows(HttpClientErrorException.class, () ->
+                makeGetRequest("/authtest/securedAdmin"));
+        assertEquals(HttpStatus.UNAUTHORIZED, exception.getStatusCode());
+    }
+
+    @Test
+    void testSecuredAdmin_User_ThenForbidden() {
+        HttpClientErrorException exception = assertThrows(HttpClientErrorException.class, () ->
+                makeGetRequest("/authtest/securedAdmin", getTokenHeader(User.Type.USER)));
+        assertEquals(HttpStatus.FORBIDDEN, exception.getStatusCode());
+    }
+
+    @Test
+    void testSecuredAdmin_Admin_ThenOK() {
+        ResponseEntity<String> response = makeGetRequest("/authtest/securedAdmin", getTokenHeader(User.Type.ADMIN));
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+    }
+
+    @Test
+    void testSecuredAdmin_Owner_ThenOK() {
+        ResponseEntity<String> response = makeGetRequest("/authtest/securedAdmin", getTokenHeader(User.Type.OWNER));
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+    }
+
+    @Test
+    void testSecuredOwner_NotAuthenticated_ThenUnauthorized() {
+        HttpClientErrorException exception = assertThrows(HttpClientErrorException.class, () ->
+                makeGetRequest("/authtest/securedOwner"));
+        assertEquals(HttpStatus.UNAUTHORIZED, exception.getStatusCode());
+    }
+
+    @Test
+    void testSecuredOwner_User_ThenForbidden() {
+        HttpClientErrorException exception = assertThrows(HttpClientErrorException.class, () ->
+                makeGetRequest("/authtest/securedOwner", getTokenHeader(User.Type.USER)));
+        assertEquals(HttpStatus.FORBIDDEN, exception.getStatusCode());
+    }
+
+    @Test
+    void testSecuredOwner_Admin_ThenForbidden() {
+        HttpClientErrorException exception = assertThrows(HttpClientErrorException.class, () ->
+                makeGetRequest("/authtest/securedOwner", getTokenHeader(User.Type.ADMIN)));
+        assertEquals(HttpStatus.FORBIDDEN, exception.getStatusCode());
+    }
+
+    @Test
+    void testSecuredOwner_Owner_ThenOK() {
+        ResponseEntity<String> response = makeGetRequest("/authtest/securedOwner", getTokenHeader(User.Type.OWNER));
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+    }
+
+    @Test
+    void testSecured_InvalidToken_ThenUnauthorized() {
+        HttpClientErrorException exception = assertThrows(HttpClientErrorException.class, () ->
+                makeGetRequest("/authtest/securedUser", getTokenHeader("someInvalidToken")));
+        assertEquals(HttpStatus.UNAUTHORIZED, exception.getStatusCode());
+    }
+}

--- a/src/test/java/edu/aau/groupc/canteenbackend/auth/security/AuthenticationInterceptorTest.java
+++ b/src/test/java/edu/aau/groupc/canteenbackend/auth/security/AuthenticationInterceptorTest.java
@@ -5,9 +5,12 @@ import edu.aau.groupc.canteenbackend.auth.services.IAuthService;
 import edu.aau.groupc.canteenbackend.endpoints.AbstractControllerTest;
 import edu.aau.groupc.canteenbackend.user.User;
 import edu.aau.groupc.canteenbackend.user.services.IUserService;
+import org.json.JSONException;
+import org.json.JSONObject;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
+import org.skyscreamer.jsonassert.JSONAssert;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpHeaders;
@@ -182,5 +185,20 @@ public class AuthenticationInterceptorTest extends AbstractControllerTest {
         HttpClientErrorException exception = assertThrows(HttpClientErrorException.class, () ->
                 makeGetRequest("/authtest/securedUser", getTokenHeader("someInvalidToken")));
         assertEquals(HttpStatus.UNAUTHORIZED, exception.getStatusCode());
+    }
+
+    /**
+     * Check if the user is correctly retrievable within the controller method.
+     * (Returning it via response is just for test simplification)
+     * @throws JSONException If response body cannot be parsed.
+     */
+    @Test
+    void testSecured_GetUserDataFromRequest() throws JSONException {
+        ResponseEntity<String> response = makeGetRequest("/authtest/securedUserReturnUserData",
+                getTokenHeader(User.Type.USER));
+
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        JSONObject responseJson = new JSONObject(response.getBody());
+        assertEquals(tokens.get(User.Type.USER).getUsername(), responseJson.getString("username"));
     }
 }

--- a/src/test/java/edu/aau/groupc/canteenbackend/auth/security/AuthenticationInterceptorTest.java
+++ b/src/test/java/edu/aau/groupc/canteenbackend/auth/security/AuthenticationInterceptorTest.java
@@ -1,163 +1,36 @@
 package edu.aau.groupc.canteenbackend.auth.security;
 
-import edu.aau.groupc.canteenbackend.auth.Auth;
-import edu.aau.groupc.canteenbackend.auth.services.IAuthService;
-import edu.aau.groupc.canteenbackend.endpoints.AbstractControllerTest;
 import edu.aau.groupc.canteenbackend.user.User;
-import edu.aau.groupc.canteenbackend.user.services.IUserService;
-import org.json.JSONException;
-import org.json.JSONObject;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestInstance;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.ValueSource;
-import org.skyscreamer.jsonassert.JSONAssert;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
-import org.springframework.test.context.ActiveProfiles;
-import org.springframework.web.client.HttpClientErrorException;
 
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import static org.junit.jupiter.api.Assertions.*;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+public class AuthenticationInterceptorTest {
 
-@ActiveProfiles("H2Database")
-@TestInstance(TestInstance.Lifecycle.PER_CLASS)
-class AuthenticationInterceptorTest extends AbstractControllerTest {
-    @Autowired
-    private IUserService userService;
+    private AuthenticationInterceptor authInterceptor = new AuthenticationInterceptor();
 
-    @Autowired
-    private IAuthService authService;
-
-    @Value("${app.auth.header}")
-    private String tokenHeader;
-
-    private Map<User.Type, Auth> tokens;
-
-    @BeforeAll
-    void setupUsersAndAuth() {
-        User user = new User("someUser", "somePassword", User.Type.USER);
-        User admin = new User("someAdmin", "somePassword", User.Type.ADMIN);
-        User owner = new User("someOwner", "somePassword", User.Type.OWNER);
-
-        userService.create(user);
-        userService.create(admin);
-        userService.create(owner);
-
-        tokens = new HashMap<>();
-        tokens.put(User.Type.USER, authService.login(user.getUsername(), user.getPassword()));
-        tokens.put(User.Type.ADMIN, authService.login(admin.getUsername(), admin.getPassword()));
-        tokens.put(User.Type.OWNER, authService.login(owner.getUsername(), owner.getPassword()));
-    }
-
-    private HttpHeaders getTokenHeader(User.Type userType) {
-        try {
-            return getTokenHeader(tokens.get(userType).getToken());
-        } catch (RuntimeException e) {
-            return new HttpHeaders();
-        }
-    }
-
-    private HttpHeaders getTokenHeader(String token) {
-        try {
-            HttpHeaders headers = new HttpHeaders();
-            headers.put(tokenHeader, List.of(token));
-            return headers;
-        } catch (RuntimeException e) {
-            return new HttpHeaders();
-        }
+    @Test
+    void requiredRole_NullArgument_ThenGuest() {
+        assertEquals(User.Type.GUEST, authInterceptor.getRequiredUserRole(null));
     }
 
     @Test
-    void testUnsecured_NotAuthenticated_ThenOK() {
-        ResponseEntity<String> response = makeGetRequest("/authtest/unsecured");
-        assertEquals(HttpStatus.OK, response.getStatusCode());
-    }
-
-    @ParameterizedTest
-    @ValueSource(strings = {"/authtest/unsecured", "/authtest/securedNoType",
-            "/authtest/securedGuest", "/authtest/securedUser"})
-    void testUser_ThenOK(String path) {
-        ResponseEntity<String> response = makeGetRequest(path, getTokenHeader(User.Type.USER));
-        assertEquals(HttpStatus.OK, response.getStatusCode());
-    }
-
-    @ParameterizedTest
-    @ValueSource(strings = {"/authtest/securedNoType", "/authtest/securedUser",
-            "/authtest/securedAdmin", "/authtest/securedOwner"})
-    void testNotAuthenticated_ThenUnauthorized(String path) {
-        HttpClientErrorException exception = assertThrows(HttpClientErrorException.class, () ->
-                makeGetRequest(path));
-        assertEquals(HttpStatus.UNAUTHORIZED, exception.getStatusCode());
+    void isAuthorized_requiredNull_ThenFalse() {
+        assertFalse(authInterceptor.isAuthorized(null, User.Type.GUEST));
     }
 
     @Test
-    void testSecuredGuest_NotAuthenticated_ThenOK() {
-        ResponseEntity<String> response = makeGetRequest("/authtest/securedGuest");
-        assertEquals(HttpStatus.OK, response.getStatusCode());
+    void isAuthorized_userTypeNull_ThenFalse() {
+        assertFalse(authInterceptor.isAuthorized(new User("", "", null), User.Type.GUEST));
     }
 
     @Test
-    void testSecuredUser_Admin_ThenOK() {
-        ResponseEntity<String> response = makeGetRequest("/authtest/securedUser", getTokenHeader(User.Type.ADMIN));
-        assertEquals(HttpStatus.OK, response.getStatusCode());
-    }
-
-    @ParameterizedTest
-    @ValueSource(strings = {"/authtest/securedUser", "/authtest/securedAdmin", "/authtest/securedOwner"})
-    void testOwner_ThenOK(String path) {
-        ResponseEntity<String> response = makeGetRequest(path, getTokenHeader(User.Type.OWNER));
-        assertEquals(HttpStatus.OK, response.getStatusCode());
-    }
-
-    @ParameterizedTest
-    @ValueSource(strings = {"/authtest/securedAdmin", "/authtest/securedOwner"})
-    void testUser_ThenForbidden(String path) {
-        HttpClientErrorException exception = assertThrows(HttpClientErrorException.class, () ->
-                makeGetRequest(path, getTokenHeader(User.Type.USER)));
-        assertEquals(HttpStatus.FORBIDDEN, exception.getStatusCode());
+    void isAuthorized_userTypeGuestRequiredGuest_ThenTrue() {
+        assertTrue(authInterceptor.isAuthorized(new User("", "", User.Type.GUEST), User.Type.GUEST));
     }
 
     @Test
-    void testSecuredAdmin_Admin_ThenOK() {
-        ResponseEntity<String> response = makeGetRequest("/authtest/securedAdmin", getTokenHeader(User.Type.ADMIN));
-        assertEquals(HttpStatus.OK, response.getStatusCode());
-    }
-
-    @Test
-    void testSecuredOwner_Admin_ThenForbidden() {
-        HttpClientErrorException exception = assertThrows(HttpClientErrorException.class, () ->
-                makeGetRequest("/authtest/securedOwner", getTokenHeader(User.Type.ADMIN)));
-        assertEquals(HttpStatus.FORBIDDEN, exception.getStatusCode());
-    }
-
-    @Test
-    void testSecured_InvalidToken_ThenUnauthorized() {
-        HttpClientErrorException exception = assertThrows(HttpClientErrorException.class, () ->
-                makeGetRequest("/authtest/securedUser", getTokenHeader("someInvalidToken")));
-        assertEquals(HttpStatus.UNAUTHORIZED, exception.getStatusCode());
-    }
-
-    /**
-     * Check if the user is correctly retrievable within the controller method.
-     * (Returning it via response is just for test simplification)
-     * @throws JSONException If response body cannot be parsed.
-     */
-    @Test
-    void testSecured_GetUserDataFromRequest() throws JSONException {
-        ResponseEntity<String> response = makeGetRequest("/authtest/securedUserReturnUserData",
-                getTokenHeader(User.Type.USER));
-
-        assertEquals(HttpStatus.OK, response.getStatusCode());
-        JSONObject responseJson = new JSONObject(response.getBody());
-        assertEquals(tokens.get(User.Type.USER).getUsername(), responseJson.getString("username"));
+    void isAuthorized_userTypeGuestRequiredUser_ThenFalse() {
+        assertFalse(authInterceptor.isAuthorized(new User("", "", User.Type.GUEST), User.Type.USER));
     }
 }

--- a/src/test/java/edu/aau/groupc/canteenbackend/auth/security/AuthenticationInterceptorTest.java
+++ b/src/test/java/edu/aau/groupc/canteenbackend/auth/security/AuthenticationInterceptorTest.java
@@ -79,9 +79,10 @@ public class AuthenticationInterceptorTest extends AbstractControllerTest {
     }
 
     @Test
-    void testSecuredNoType_NotAuthenticated_ThenOK() {
-        ResponseEntity<String> response = makeGetRequest("/authtest/securedNoType");
-        assertEquals(HttpStatus.OK, response.getStatusCode());
+    void testSecuredNoType_NotAuthenticated_ThenUnauthorized() {
+        HttpClientErrorException exception = assertThrows(HttpClientErrorException.class, () ->
+                makeGetRequest("/authtest/securedNoType"));
+        assertEquals(HttpStatus.UNAUTHORIZED, exception.getStatusCode());
     }
 
     @Test

--- a/src/test/java/edu/aau/groupc/canteenbackend/endpoints/AbstractControllerTest.java
+++ b/src/test/java/edu/aau/groupc/canteenbackend/endpoints/AbstractControllerTest.java
@@ -4,11 +4,10 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.web.server.LocalServerPort;
-import org.springframework.http.HttpEntity;
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.HttpMethod;
-import org.springframework.http.ResponseEntity;
+import org.springframework.http.*;
 import org.springframework.web.client.RestTemplate;
+
+import java.util.List;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 public class AbstractControllerTest {
@@ -21,7 +20,12 @@ public class AbstractControllerTest {
     @Autowired
     protected RestTemplate restTemplate;
 
-    protected HttpHeaders headers = new HttpHeaders();
+    private final HttpHeaders defaultHeaders;
+
+    public AbstractControllerTest() {
+        defaultHeaders = new HttpHeaders();
+        defaultHeaders.setContentType(MediaType.APPLICATION_JSON);
+    }
 
     private String getProtocol() {
         return httpsEnabled ? "https" : "http";
@@ -32,10 +36,39 @@ public class AbstractControllerTest {
     }
 
     protected ResponseEntity<String> makeGetRequest(String uri) {
+        return makeGetRequest(uri, new HttpHeaders());
+    }
+
+    protected ResponseEntity<String> makeGetRequest(String uri, HttpHeaders headers) {
+        setDefaultHeaders(headers);
         return restTemplate.exchange(
                 createURLWithPort(uri),
                 HttpMethod.GET,
                 new HttpEntity<>(null, headers),
                 String.class);
+    }
+
+    protected ResponseEntity<String> makePostRequest(String uri, String body) {
+        return makePostRequest(uri, body, new HttpHeaders());
+    }
+
+    protected ResponseEntity<String> makePostRequest(String uri, String body, HttpHeaders headers) {
+        setDefaultHeaders(headers);
+        return restTemplate.exchange(
+                createURLWithPort(uri),
+                HttpMethod.POST,
+                new HttpEntity<>(body, headers),
+                String.class);
+    }
+
+    private void setDefaultHeaders(HttpHeaders headers) {
+        for (String k: defaultHeaders.keySet()) {
+            List<String> values = defaultHeaders.get(k);
+            if (values != null) {
+                for (String v: values) {
+                    headers.addIfAbsent(k, v);
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
Implemented request interceptor to provide easy endpoint controller protection.

- Endpoint methods can now be annotated with `@Secured(User.Type)` to allow only authenticated users having at least the specified `User.Type` to call the endpoint method.
- Default value of `@Secured` is `USER` since it's the lowest role where authentication is required.
- The authenticated user data can be retrieved within a `@Secured` Controller method by specifying the `HttpServletRequest req` as a method parameter. Calling `req.getAttribute("user")` will return a `User` object of the authenticated user. 