### PR TITLE
Feature/performance tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,7 +53,7 @@ jobs:
       - run:
           name: Install Java 11
           command: sudo apt-get -y update && sudo apt-get -y install openjdk-11-jdk-headless
-      # wait for the server to start responding. We expect Bad Request 400 once it starts listening.
+      # Wait for the server to start responding. We expect Bad Request 400 once it starts listening.
       # so override the shell and have the last command be the : { null } command to force exit code 0.
       - run:
           name: Wait for backend to start
@@ -61,6 +61,7 @@ jobs:
           command: |
             wget --retry-connrefused --waitretry=2 --read-timeout=20 --timeout=15 -t 20 http://localhost:8080/
             :
+      # Run all performance tests in src/test/jmeter of the repository
       - run:
           name: Run performance tests
           command: |
@@ -71,17 +72,24 @@ jobs:
 
 workflows:
   main:
+    when:
+      not:
+        equal: [ scheduled_pipeline, << pipeline.trigger_source >> ]
     jobs:
-      #- build-and-test:
-      #    context: SonarCloud
+      - build-and-test:
+          context: SonarCloud
+      - build-and-deploy:
+          context: Heroku-<< pipeline.git.branch >>
+          requires:
+            # Deploy after testing.
+            - build-and-test
+          filters:
+            branches:
+              only:
+                - main
+                - development
+  nighly:
+    when:
+      equal: [ scheduled_pipeline, << pipeline.trigger_source >> ]
+    jobs:
       - performance-tests
-      #- build-and-deploy:
-      #    context: Heroku-<< pipeline.git.branch >>
-      #    requires:
-      #      # Deploy after testing.
-      #      - build-and-test
-      #    filters:
-      #      branches:
-      #        only:
-      #          - main
-      #          - development

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,9 @@
 version: 2.1
 
 parameters:
+  run-main:
+    type: boolean
+    default: true
   run-performance-tests:
     type: boolean
     default: false
@@ -78,8 +81,7 @@ jobs:
 workflows:
   main:
     when:
-      not:
-        << pipeline.parameters.run-performance-tests >>
+      << pipeline.parameters.run-main >>
     jobs:
       - build-and-test:
           context: SonarCloud

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,7 +57,7 @@ jobs:
           name: Wait for backend to start
           shell: /bin/sh
           command: |
-            wget --retry-connrefused --waitretry=1 --read-timeout=20 --timeout=15 -t 10 http://localhost:8080/
+            wget --retry-connrefused --waitretry=1 --read-timeout=20 --timeout=15 -t 20 http://localhost:8080/
             :
       - run:
           name: Install Java 11

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,17 +50,17 @@ jobs:
           name: Run backend
           command: mvn spring-boot:run
           background: true
-        # wait for the server to start responding. We expect Bad Request 400 once it starts listening.
-        # so override the shell and have the last command be the : { null } command to force exit code 0.
+      - run:
+          name: Install Java 11
+          command: sudo apt-get -y update && sudo apt-get -y install openjdk-11-jdk-headless
+      # wait for the server to start responding. We expect Bad Request 400 once it starts listening.
+      # so override the shell and have the last command be the : { null } command to force exit code 0.
       - run:
           name: Wait for backend to start
           shell: /bin/sh
           command: |
             wget --retry-connrefused --waitretry=2 --read-timeout=20 --timeout=15 -t 20 http://localhost:8080/
             :
-      - run:
-          name: Install Java 11
-          command: sudo apt-get -y update && sudo apt-get -y install openjdk-11-jdk-headless
       - run:
           name: Run performance tests
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ orbs:
 jobs:
   build-and-test:
     docker:
-      - image: cimg/openjdk:16.0
+      - image: cimg/openjdk:17.0
     steps:
       - checkout
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -75,13 +75,13 @@ workflows:
       #- build-and-test:
       #    context: SonarCloud
       - performance-tests
-      - build-and-deploy:
-          context: Heroku-<< pipeline.git.branch >>
-          requires:
-            # Deploy after testing.
-            - build-and-test
-          filters:
-            branches:
-              only:
-                - main
-                - development
+      #- build-and-deploy:
+      #    context: Heroku-<< pipeline.git.branch >>
+      #    requires:
+      #      # Deploy after testing.
+      #      - build-and-test
+      #    filters:
+      #      branches:
+      #        only:
+      #          - main
+      #          - development

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,11 +36,45 @@ jobs:
           name: Deploy container
           command: HEROKU_API_KEY=${HEROKU_API_KEY} heroku container:release -a ${HEROKU_APP_NAME} web
 
+  performance-tests:
+    docker:
+      # first `image` defines the primary container where all steps will run
+      # if no `name:` is provided, services are accessible through `localhost`
+      - image: cimg/openjdk:17.0
+      - image: postgres
+        environment:
+          POSTGRES_PASSWORD: mysecretpassword
+    steps:
+      - checkout
+      - run:
+          name: Run backend
+          command: mvn spring-boot:run
+          working_directory: /opt/backend
+          background: true
+        # wait for the server to start responding. We expect Bad Request 400 once it starts listening.
+        # so override the shell and have the last command be the : { null } command to force exit code 0.
+      - run:
+          name: Wait for backend to start
+          shell: /bin/sh
+          command: |
+            wget --retry-connrefused --waitretry=1 --read-timeout=20 --timeout=15 -t 10 http://localhost:8080/
+            :
+      - run:
+          name: Run performance tests
+          command: |
+            sudo apt-get -y update && sudo apt-get -y install openjdk-11-jdk-headless
+            export JAVA_HOME=$(dirname $(dirname $(readlink -f $(which javac))))
+            echo $JAVA_HOME
+            mvn verify -Pperformance -f pom.xml
+      - store_artifacts:
+          path: target/jmeter/reports
+
 workflows:
   main:
     jobs:
-      - build-and-test:
-          context: SonarCloud
+      #- build-and-test:
+      #    context: SonarCloud
+      - performance-tests
       - build-and-deploy:
           context: Heroku-<< pipeline.git.branch >>
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ orbs:
 jobs:
   build-and-test:
     docker:
-      - image: cimg/openjdk:17.0
+      - image: cimg/openjdk:16.0
     steps:
       - checkout
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,7 +74,7 @@ workflows:
   main:
     when:
       not:
-        equal: [ scheduled_pipeline, << pipeline.trigger_source >> ]
+        << pipeline.parameters.run-performance-tests >>
     jobs:
       - build-and-test:
           context: SonarCloud
@@ -90,6 +90,6 @@ workflows:
                 - development
   nighly:
     when:
-      equal: [ scheduled_pipeline, << pipeline.trigger_source >> ]
+      << pipeline.parameters.run-performance-tests >>
     jobs:
       - performance-tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,7 +49,6 @@ jobs:
       - run:
           name: Run backend
           command: mvn spring-boot:run
-          #working_directory: /opt/backend
           background: true
         # wait for the server to start responding. We expect Bad Request 400 once it starts listening.
         # so override the shell and have the last command be the : { null } command to force exit code 0.
@@ -57,7 +56,7 @@ jobs:
           name: Wait for backend to start
           shell: /bin/sh
           command: |
-            wget --retry-connrefused --waitretry=1 --read-timeout=20 --timeout=15 -t 20 http://localhost:8080/
+            wget --retry-connrefused --waitretry=2 --read-timeout=20 --timeout=15 -t 20 http://localhost:8080/
             :
       - run:
           name: Install Java 11

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,7 +49,7 @@ jobs:
       - run:
           name: Run backend
           command: mvn spring-boot:run
-          working_directory: /opt/backend
+          #working_directory: /opt/backend
           background: true
         # wait for the server to start responding. We expect Bad Request 400 once it starts listening.
         # so override the shell and have the last command be the : { null } command to force exit code 0.

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,11 +60,12 @@ jobs:
             wget --retry-connrefused --waitretry=1 --read-timeout=20 --timeout=15 -t 10 http://localhost:8080/
             :
       - run:
+          name: Install Java 11
+          command: sudo apt-get -y update && sudo apt-get -y install openjdk-11-jdk-headless
+      - run:
           name: Run performance tests
           command: |
-            sudo apt-get -y update && sudo apt-get -y install openjdk-11-jdk-headless
             export JAVA_HOME=$(dirname $(dirname $(readlink -f $(which javac))))
-            echo $JAVA_HOME
             mvn verify -Pperformance -f pom.xml
       - store_artifacts:
           path: target/jmeter/reports

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,10 @@
 version: 2.1
 
+parameters:
+  run-performance-tests:
+    type: boolean
+    default: false
+
 orbs:
   sonarcloud: sonarsource/sonarcloud@1.0.3
 

--- a/.run/canteen-backend [verify,-Pperformance].run.xml
+++ b/.run/canteen-backend [verify,-Pperformance].run.xml
@@ -1,0 +1,43 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Run performance tests" type="MavenRunConfiguration" factoryName="Maven" nameIsGenerated="true">
+    <MavenSettings>
+      <option name="myGeneralSettings" />
+      <option name="myRunnerSettings">
+        <MavenRunnerSettings>
+          <option name="delegateBuildToMaven" value="false" />
+          <option name="environmentProperties">
+            <map />
+          </option>
+          <option name="jreName" value="temurin-11" />
+          <option name="mavenProperties">
+            <map />
+          </option>
+          <option name="passParentEnv" value="true" />
+          <option name="runMavenInBackground" value="true" />
+          <option name="skipTests" value="false" />
+          <option name="vmOptions" value="" />
+        </MavenRunnerSettings>
+      </option>
+      <option name="myRunnerParameters">
+        <MavenRunnerParameters>
+          <option name="profiles">
+            <set />
+          </option>
+          <option name="goals">
+            <list>
+              <option value="verify" />
+              <option value="-Pperformance" />
+            </list>
+          </option>
+          <option name="pomFileName" />
+          <option name="profilesMap">
+            <map />
+          </option>
+          <option name="resolveToWorkspace" value="false" />
+          <option name="workingDirPath" value="$PROJECT_DIR$" />
+        </MavenRunnerParameters>
+      </option>
+    </MavenSettings>
+    <method v="2" />
+  </configuration>
+</component>

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-ARG BUILD_IMAGE=maven:3.8-openjdk-17
-ARG RUNTIME_IMAGE=openjdk:17-jdk-slim
+ARG BUILD_IMAGE=maven:3.8-openjdk-16
+ARG RUNTIME_IMAGE=openjdk:16-jdk-slim
 
 # pull all maven dependencies
 FROM ${BUILD_IMAGE} as dependencies

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-ARG BUILD_IMAGE=maven:3.8-openjdk-16
-ARG RUNTIME_IMAGE=openjdk:16-jdk-slim
+ARG BUILD_IMAGE=maven:3.8-openjdk-17
+ARG RUNTIME_IMAGE=openjdk:17-jdk-slim
 
 # pull all maven dependencies
 FROM ${BUILD_IMAGE} as dependencies

--- a/README.md
+++ b/README.md
@@ -21,6 +21,18 @@ Using cmd, it can either be run using `mvn spring-boot:run` or `java -jar ./targ
 
 Tests can be executed directly through IntelliJ or using `mvn test`.
 
+### Performance Tests:
+Performance tests are implemented using [JMeter](https://jmeter.apache.org/download_jmeter.cgi). This tool allows for the easy creation of performance tests by simulating a configurable number of users sending configurable HTTP requests. The tool also comes with a GUI for test plan creation.
+
+Once configured, test plans can be saved as `jmx` files. Placing those files into the `src/test/jmeter` folder of the backend will automatically include them for performance test execution.
+
+#### Test Execution
+Performance tests are configured to be run on CircleCI as regular nightly builds.
+
+To run them locally, first start the backend by running `mvn spring-boot:run` (requires local PostgreSQL setup) and then run the tests using `mvn verify -Pperformance`.
+
+**Please Note**: The current version of JMeter used in this setup is partly incompatible with Java 17. In particular, HTML test reports are not generated in a Java 17 environment.
+To bypass this issue, you can start the backend in a standard Java 17 environment, and then run the performance tests in a Java <17 environment. To change the Java version used by Maven you can set the `JAVA_HOME` environment variable to the install directory of your JDK.
 ## Database configuration
 To allow for local testing, the database used by this application can be configured in the `src/main/resources/application.properties`. The three properties of `spring.datasource` allow to configure the database url, username and password. 
 

--- a/README.md
+++ b/README.md
@@ -33,6 +33,10 @@ To run them locally, first start the backend by running `mvn spring-boot:run` (r
 
 **Please Note**: The current version of JMeter used in this setup is partly incompatible with Java 17. In particular, HTML test reports are not generated in a Java 17 environment.
 To bypass this issue, you can start the backend in a standard Java 17 environment, and then run the performance tests in a Java <17 environment. To change the Java version used by Maven you can set the `JAVA_HOME` environment variable to the install directory of your JDK.
+
+A run config is provided which uses Java 11 to execute all performance tests. If Java 11 is not installed, you might need to manually change the JDK in the run configuration to use it.
+(Note: This run config launches _only_ the performance tests. The application still has to be started explicitly.)
+
 ## Database configuration
 To allow for local testing, the database used by this application can be configured in the `src/main/resources/application.properties`. The three properties of `spring.datasource` allow to configure the database url, username and password. 
 

--- a/pom.xml
+++ b/pom.xml
@@ -156,6 +156,14 @@
                             <generateReports>true</generateReports>
                         </configuration>
                     </plugin>
+
+                    <plugin>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <version>3.0.0-M5</version>
+                        <configuration>
+                            <skipTests>true</skipTests>
+                        </configuration>
+                    </plugin>
                 </plugins>
             </build>
         </profile>

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
     <name>canteen-backend</name>
     <description>canteen-backend</description>
     <properties>
-        <java.version>16</java.version>
+        <java.version>17</java.version>
         <sonar.organization>elsantner</sonar.organization>
         <sonar.host.url>https://sonarcloud.io</sonar.host.url>
     </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
     <name>canteen-backend</name>
     <description>canteen-backend</description>
     <properties>
-        <java.version>17</java.version>
+        <java.version>16</java.version>
         <sonar.organization>elsantner</sonar.organization>
         <sonar.host.url>https://sonarcloud.io</sonar.host.url>
     </properties>
@@ -73,6 +73,12 @@
             <version>1.18.22</version>
             <scope>provided</scope>
         </dependency>
+
+        <dependency>
+            <groupId>com.lazerycode.jmeter</groupId>
+            <artifactId>jmeter-maven-plugin</artifactId>
+            <version>3.5.0</version>
+        </dependency>
     </dependencies>
 
     <build>
@@ -110,7 +116,49 @@
                     </execution>
                 </executions>
             </plugin>
+
         </plugins>
     </build>
+
+    <profiles>
+        <profile>
+            <id>performance</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>com.lazerycode.jmeter</groupId>
+                        <artifactId>jmeter-maven-plugin</artifactId>
+                        <version>3.5.0</version>
+                        <executions>
+                            <!-- Generate JMeter configuration -->
+                            <execution>
+                                <id>configuration</id>
+                                <goals>
+                                    <goal>configure</goal>
+                                </goals>
+                            </execution>
+                            <!-- Run JMeter tests -->
+                            <execution>
+                                <id>jmeter-tests</id>
+                                <goals>
+                                    <goal>jmeter</goal>
+                                </goals>
+                            </execution>
+                            <!-- Fail build on errors in test -->
+                            <execution>
+                                <id>jmeter-check-results</id>
+                                <goals>
+                                    <goal>results</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                        <configuration>
+                            <generateReports>true</generateReports>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 
 </project>

--- a/src/test/jmeter/GetDishes.jmx
+++ b/src/test/jmeter/GetDishes.jmx
@@ -1,0 +1,168 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jmeterTestPlan version="1.2" properties="5.0" jmeter="5.4.3">
+  <hashTree>
+    <TestPlan guiclass="TestPlanGui" testclass="TestPlan" testname="Get Dishes" enabled="true">
+      <stringProp name="TestPlan.comments"></stringProp>
+      <boolProp name="TestPlan.functional_mode">false</boolProp>
+      <boolProp name="TestPlan.tearDown_on_shutdown">true</boolProp>
+      <boolProp name="TestPlan.serialize_threadgroups">false</boolProp>
+      <elementProp name="TestPlan.user_defined_variables" elementType="Arguments" guiclass="ArgumentsPanel" testclass="Arguments" testname="User Defined Variables" enabled="true">
+        <collectionProp name="Arguments.arguments"/>
+      </elementProp>
+      <stringProp name="TestPlan.user_define_classpath"></stringProp>
+    </TestPlan>
+    <hashTree>
+      <ThreadGroup guiclass="ThreadGroupGui" testclass="ThreadGroup" testname="Thread Group" enabled="true">
+        <stringProp name="ThreadGroup.on_sample_error">continue</stringProp>
+        <elementProp name="ThreadGroup.main_controller" elementType="LoopController" guiclass="LoopControlPanel" testclass="LoopController" testname="Loop Controller" enabled="true">
+          <boolProp name="LoopController.continue_forever">false</boolProp>
+          <stringProp name="LoopController.loops">1000</stringProp>
+        </elementProp>
+        <stringProp name="ThreadGroup.num_threads">100</stringProp>
+        <stringProp name="ThreadGroup.ramp_time">1</stringProp>
+        <boolProp name="ThreadGroup.scheduler">false</boolProp>
+        <stringProp name="ThreadGroup.duration"></stringProp>
+        <stringProp name="ThreadGroup.delay"></stringProp>
+        <boolProp name="ThreadGroup.same_user_on_next_iteration">true</boolProp>
+      </ThreadGroup>
+      <hashTree>
+        <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="Get Dishes" enabled="true">
+          <elementProp name="HTTPsampler.Arguments" elementType="Arguments" guiclass="HTTPArgumentsPanel" testclass="Arguments" testname="User Defined Variables" enabled="true">
+            <collectionProp name="Arguments.arguments"/>
+          </elementProp>
+          <stringProp name="HTTPSampler.domain">localhost</stringProp>
+          <stringProp name="HTTPSampler.port">8080</stringProp>
+          <stringProp name="HTTPSampler.protocol">http</stringProp>
+          <stringProp name="HTTPSampler.contentEncoding"></stringProp>
+          <stringProp name="HTTPSampler.path">dish</stringProp>
+          <stringProp name="HTTPSampler.method">GET</stringProp>
+          <boolProp name="HTTPSampler.follow_redirects">true</boolProp>
+          <boolProp name="HTTPSampler.auto_redirects">false</boolProp>
+          <boolProp name="HTTPSampler.use_keepalive">true</boolProp>
+          <boolProp name="HTTPSampler.DO_MULTIPART_POST">false</boolProp>
+          <stringProp name="HTTPSampler.embedded_url_re"></stringProp>
+          <stringProp name="HTTPSampler.connect_timeout"></stringProp>
+          <stringProp name="HTTPSampler.response_timeout"></stringProp>
+        </HTTPSamplerProxy>
+        <hashTree/>
+        <ResultCollector guiclass="TableVisualizer" testclass="ResultCollector" testname="View Results in Table" enabled="true">
+          <boolProp name="ResultCollector.error_logging">false</boolProp>
+          <objProp>
+            <name>saveConfig</name>
+            <value class="SampleSaveConfiguration">
+              <time>true</time>
+              <latency>true</latency>
+              <timestamp>true</timestamp>
+              <success>true</success>
+              <label>true</label>
+              <code>true</code>
+              <message>true</message>
+              <threadName>true</threadName>
+              <dataType>true</dataType>
+              <encoding>false</encoding>
+              <assertions>true</assertions>
+              <subresults>true</subresults>
+              <responseData>false</responseData>
+              <samplerData>false</samplerData>
+              <xml>false</xml>
+              <fieldNames>true</fieldNames>
+              <responseHeaders>false</responseHeaders>
+              <requestHeaders>false</requestHeaders>
+              <responseDataOnError>false</responseDataOnError>
+              <saveAssertionResultsFailureMessage>true</saveAssertionResultsFailureMessage>
+              <assertionsResultsToSave>0</assertionsResultsToSave>
+              <bytes>true</bytes>
+              <sentBytes>true</sentBytes>
+              <url>true</url>
+              <threadCounts>true</threadCounts>
+              <idleTime>true</idleTime>
+              <connectTime>true</connectTime>
+            </value>
+          </objProp>
+          <stringProp name="filename">results.csv</stringProp>
+        </ResultCollector>
+        <hashTree/>
+        <ResultCollector guiclass="RespTimeGraphVisualizer" testclass="ResultCollector" testname="Response Time Graph" enabled="true">
+          <boolProp name="ResultCollector.error_logging">false</boolProp>
+          <objProp>
+            <name>saveConfig</name>
+            <value class="SampleSaveConfiguration">
+              <time>true</time>
+              <latency>true</latency>
+              <timestamp>true</timestamp>
+              <success>true</success>
+              <label>true</label>
+              <code>true</code>
+              <message>true</message>
+              <threadName>true</threadName>
+              <dataType>true</dataType>
+              <encoding>false</encoding>
+              <assertions>true</assertions>
+              <subresults>true</subresults>
+              <responseData>false</responseData>
+              <samplerData>false</samplerData>
+              <xml>false</xml>
+              <fieldNames>true</fieldNames>
+              <responseHeaders>false</responseHeaders>
+              <requestHeaders>false</requestHeaders>
+              <responseDataOnError>false</responseDataOnError>
+              <saveAssertionResultsFailureMessage>true</saveAssertionResultsFailureMessage>
+              <assertionsResultsToSave>0</assertionsResultsToSave>
+              <bytes>true</bytes>
+              <sentBytes>true</sentBytes>
+              <url>true</url>
+              <threadCounts>true</threadCounts>
+              <idleTime>true</idleTime>
+              <connectTime>true</connectTime>
+            </value>
+          </objProp>
+          <stringProp name="filename"></stringProp>
+          <stringProp name="RespTimeGraph.interval">50</stringProp>
+        </ResultCollector>
+        <hashTree/>
+        <ResultCollector guiclass="SummaryReport" testclass="ResultCollector" testname="Summary Report" enabled="true">
+          <boolProp name="ResultCollector.error_logging">false</boolProp>
+          <objProp>
+            <name>saveConfig</name>
+            <value class="SampleSaveConfiguration">
+              <time>true</time>
+              <latency>true</latency>
+              <timestamp>true</timestamp>
+              <success>true</success>
+              <label>true</label>
+              <code>true</code>
+              <message>true</message>
+              <threadName>true</threadName>
+              <dataType>true</dataType>
+              <encoding>false</encoding>
+              <assertions>true</assertions>
+              <subresults>true</subresults>
+              <responseData>false</responseData>
+              <samplerData>false</samplerData>
+              <xml>false</xml>
+              <fieldNames>true</fieldNames>
+              <responseHeaders>false</responseHeaders>
+              <requestHeaders>false</requestHeaders>
+              <responseDataOnError>false</responseDataOnError>
+              <saveAssertionResultsFailureMessage>true</saveAssertionResultsFailureMessage>
+              <assertionsResultsToSave>0</assertionsResultsToSave>
+              <bytes>true</bytes>
+              <sentBytes>true</sentBytes>
+              <url>true</url>
+              <threadCounts>true</threadCounts>
+              <idleTime>true</idleTime>
+              <connectTime>true</connectTime>
+            </value>
+          </objProp>
+          <stringProp name="filename"></stringProp>
+        </ResultCollector>
+        <hashTree/>
+        <UniformRandomTimer guiclass="UniformRandomTimerGui" testclass="UniformRandomTimer" testname="Uniform Random Timer" enabled="false">
+          <stringProp name="ConstantTimer.delay">2000.0</stringProp>
+          <stringProp name="RandomTimer.range">3000.0</stringProp>
+        </UniformRandomTimer>
+        <hashTree/>
+      </hashTree>
+    </hashTree>
+  </hashTree>
+</jmeterTestPlan>

--- a/src/test/jmeter/GetDishes.jmx
+++ b/src/test/jmeter/GetDishes.jmx
@@ -16,7 +16,7 @@
         <stringProp name="ThreadGroup.on_sample_error">continue</stringProp>
         <elementProp name="ThreadGroup.main_controller" elementType="LoopController" guiclass="LoopControlPanel" testclass="LoopController" testname="Loop Controller" enabled="true">
           <boolProp name="LoopController.continue_forever">false</boolProp>
-          <stringProp name="LoopController.loops">1000</stringProp>
+          <stringProp name="LoopController.loops">1</stringProp>
         </elementProp>
         <stringProp name="ThreadGroup.num_threads">100</stringProp>
         <stringProp name="ThreadGroup.ramp_time">1</stringProp>


### PR DESCRIPTION
## Performance Tests:
Performance tests are implemented using [JMeter](https://jmeter.apache.org/download_jmeter.cgi). This tool allows for the easy creation of performance tests by simulating a configurable number of users sending configurable HTTP requests. The tool also comes with a GUI for test plan creation. 

Once configured, test plans can be saved as `jmx` files. Placing those files into the `src/test/jmeter` folder of the backend will automatically include them for performance test execution.

### Test Exectuion
Performance tests are configured to be run on CircleCI as regular nightly builds.

To run them locally, first start the backend by running `mvn spring-boot:run` (requires local PostgreSQL setup) and then run the tests using `mvn verify -Pperformance`.

**Please Note**: The current version of JMeter used in this setup is partly incompatible with Java 17. In particular, HTML test reports are not generated in a Java 17 environment.
To bypass this issue, you can start the backend in a standard Java 17 environment, and then run the performance tests in a Java <17 environment. To change the Java version used by Maven you can set the `JAVA_HOME` environment variable to the install directory of your JDK.  